### PR TITLE
updated dockerfile for native alpine (pull request)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 ## brother\_ql\_web\_docker
 
 This repository contains Dockerfiles to create images with deployments
-of [brother\_ql\_web](https://github.com/pklaus/brother_ql_web), a web interface
+of [brother\_ql\_web](https://github.com/fionnb/brother_ql_web), a web interface
 to print labels with Brother's QL-series label printers.
 
-Ready to use images can be found on Docker hub: [pklaus/brother\_ql\_web](https://hub.docker.com/r/pklaus/brother_ql_web/).
+Ready to use images can be found on Docker hub: [fionnb/brother\_ql\_web](https://hub.docker.com/r/fionnb/brother_ql_web/).
 
 ### Available images / tags
 
@@ -22,11 +22,11 @@ An example for running the application:
       --rm \
       --device=/dev/usb/lp0 \
       --publish 8013:8013 \
-      pklaus/brother_ql_web:alpine-3.7_b1af3e8 \
+      fionnb/brother_ql_web:rpi-latest \
       ./brother_ql_web.py --model QL-700 file:///dev/usb/lp0
 
-Here, we use the image `pklaus/brother_ql_web:alpine-3.7_5f1447d`
-made for x86\_64 CPUs.
+Here, we use the image `fionnb/brother_ql_web:rpi-latest
+made for Raspberry Pi.
 
 ### Compressed Image Sizes
 

--- a/resin-raspberry-pi-alpine-3.6/Dockerfile
+++ b/resin-raspberry-pi-alpine-3.6/Dockerfile
@@ -1,10 +1,7 @@
-FROM resin/raspberry-pi-alpine:3.6
-# or for the Raspberry Pi 2/3 (identical):
-#FROM resin/raspberry-pi2-alpine:3.6
-#FROM resin/raspberrypi3-alpine:3.6
+FROM alpine:latest
 
 # https://docs.resin.io/runtime/resin-base-images/#resin-xbuild-qemu
-RUN [ "cross-build-start" ]
+#RUN [ "cross-build-start" ]
 
 RUN apk add --update --no-cache --virtual .build-deps  \
     git
@@ -28,7 +25,5 @@ RUN apk del .build-deps
 
 EXPOSE 8013
 
-RUN [ "cross-build-end" ]
-
-#CMD [ "brother_ql_create", "--help" ]
+#RUN [ "cross-build-end" ]
 CMD [ "./brother_ql_web.py", "--model", "QL-700", "file:///dev/usb/lp0" ]


### PR DESCRIPTION
Since "resin" images have been deprecated long ago and alpine is now natively providing rpi base images I tried to adapt your dockerfile - et voila - it works. You might want to give your docker hub images an update :-)